### PR TITLE
feat: add comments at posts

### DIFF
--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -1,0 +1,59 @@
+---
+// Giscus - A comments system powered by GitHub Discussions
+// Configure at: https://giscus.app
+---
+
+<section class="giscus-container mt-12">
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="iaurg/segredo-dev"
+    data-repo-id="MDEwOlJlcG9zaXRvcnkzODAzOTE4ODA="
+    data-category="Announcements"
+    data-category-id="DIC_kwDOFqxRyM4C1G4P"
+    data-mapping="title"
+    data-strict="0"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="bottom"
+    data-theme="preferred_color_scheme"
+    data-lang="en"
+    data-loading="lazy"
+    crossorigin="anonymous"
+    async
+  ></script>
+</section>
+
+<script>
+  // Update giscus theme when the page theme changes
+  document.addEventListener('astro:page-load', () => {
+    const updateGiscusTheme = () => {
+      const theme = document.documentElement.classList.contains('dark')
+        ? 'dark'
+        : 'light'
+
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        'iframe.giscus-frame'
+      )
+      if (iframe) {
+        iframe.contentWindow?.postMessage(
+          { giscus: { setConfig: { theme } } },
+          'https://giscus.app'
+        )
+      }
+    }
+
+    // Observe theme changes
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.attributeName === 'class') {
+          updateGiscusTheme()
+        }
+      })
+    })
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+  })
+</script>

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -15,13 +15,22 @@
     data-reactions-enabled="1"
     data-emit-metadata="0"
     data-input-position="bottom"
-    data-theme="preferred_color_scheme"
+    data-theme="light"
     data-lang="en"
     data-loading="lazy"
     crossorigin="anonymous"
     async
   ></script>
 </section>
+
+<script is:inline data-astro-rerun>
+  // Initialize Giscus with the correct theme based on current state
+  const isDark = document.documentElement.classList.contains('dark')
+  const giscusScript = document.querySelector('script[src*="giscus.app/client.js"]')
+  if (giscusScript) {
+    giscusScript.setAttribute('data-theme', isDark ? 'dark' : 'light')
+  }
+</script>
 
 <script>
   // Update giscus theme when the page theme changes

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -27,9 +27,7 @@
   // Initialize Giscus with the correct theme based on current state
   ;(() => {
     const isDark = document.documentElement.classList.contains('dark')
-    // Find the Giscus script in the preceding section
-    const section = document.currentScript?.previousElementSibling
-    const giscusScript = section?.querySelector('script[src*="giscus.app"]')
+    const giscusScript = document.querySelector('script[src*="giscus.app/client.js"]')
     if (giscusScript) {
       giscusScript.setAttribute('data-theme', isDark ? 'dark' : 'light')
     }

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -25,10 +25,11 @@
 
 <script is:inline data-astro-rerun>
   // Initialize Giscus with the correct theme based on current state
-  // This script runs after the Giscus script element is in the DOM
   ;(() => {
     const isDark = document.documentElement.classList.contains('dark')
-    const giscusScript = document.querySelector('script[src*="giscus.app/client.js"]')
+    // Find the Giscus script in the preceding section
+    const section = document.currentScript?.previousElementSibling
+    const giscusScript = section?.querySelector('script[src*="giscus.app"]')
     if (giscusScript) {
       giscusScript.setAttribute('data-theme', isDark ? 'dark' : 'light')
     }

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -55,5 +55,8 @@
       attributes: true,
       attributeFilter: ['class'],
     })
+
+    // Ensure the initial theme state is synchronized with Giscus on page load
+    updateGiscusTheme()
   })
 </script>

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -4,28 +4,59 @@
 ---
 
 <section class="giscus-container mt-12">
-  <script
-    src="https://giscus.app/client.js"
-    data-repo="iaurg/segredo-dev"
-    data-repo-id="MDEwOlJlcG9zaXRvcnkzODAzOTE4ODA="
-    data-category="Announcements"
-    data-category-id="DIC_kwDOFqxRyM4C1G4P"
-    data-mapping="title"
-    data-strict="0"
-    data-reactions-enabled="1"
-    data-emit-metadata="0"
-    data-input-position="bottom"
-    data-theme="preferred_color_scheme"
-    data-lang="en"
-    data-loading="lazy"
-    crossorigin="anonymous"
-    async
-  ></script>
+  <div class="giscus"></div>
 </section>
 
 <script>
-  // Update giscus theme when the page theme changes
-  document.addEventListener('astro:page-load', () => {
+  function loadGiscus() {
+    const container = document.querySelector('.giscus-container .giscus')
+    if (!container) return
+
+    // Clear any existing giscus content
+    container.innerHTML = ''
+
+    // Remove any existing giscus script and iframe to allow reinitialization
+    const existingScript = document.querySelector(
+      'script[src*="giscus.app/client.js"]'
+    )
+    if (existingScript) {
+      existingScript.remove()
+    }
+    const existingIframe = document.querySelector('iframe.giscus-frame')
+    if (existingIframe) {
+      existingIframe.remove()
+    }
+
+    // Determine current theme
+    const theme = document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light'
+
+    // Create and append the giscus script
+    const script = document.createElement('script')
+    script.src = 'https://giscus.app/client.js'
+    script.setAttribute('data-repo', 'iaurg/segredo-dev')
+    script.setAttribute('data-repo-id', 'MDEwOlJlcG9zaXRvcnkzODAzOTE4ODA=')
+    script.setAttribute('data-category', 'Announcements')
+    script.setAttribute('data-category-id', 'DIC_kwDOFqxRyM4C1G4P')
+    script.setAttribute('data-mapping', 'title')
+    script.setAttribute('data-strict', '0')
+    script.setAttribute('data-reactions-enabled', '1')
+    script.setAttribute('data-emit-metadata', '0')
+    script.setAttribute('data-input-position', 'bottom')
+    script.setAttribute('data-theme', theme)
+    script.setAttribute('data-lang', 'en')
+    script.setAttribute('data-loading', 'lazy')
+    script.crossOrigin = 'anonymous'
+    script.async = true
+
+    container.appendChild(script)
+
+    // Setup theme observer for dynamic theme changes
+    setupThemeObserver()
+  }
+
+  function setupThemeObserver() {
     const updateGiscusTheme = () => {
       const theme = document.documentElement.classList.contains('dark')
         ? 'dark'
@@ -42,7 +73,7 @@
       }
     }
 
-    // Observe theme changes
+    // Observe theme changes on the document element
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.attributeName === 'class') {
@@ -56,6 +87,7 @@
       attributeFilter: ['class'],
     })
 
+    // Clean up observer on page swap
     document.addEventListener(
       'astro:before-swap',
       () => {
@@ -63,8 +95,7 @@
       },
       { once: true }
     )
+  }
 
-    // Ensure the initial theme state is synchronized with Giscus on page load
-    updateGiscusTheme()
-  })
+  document.addEventListener('astro:page-load', loadGiscus)
 </script>

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -56,6 +56,14 @@
       attributeFilter: ['class'],
     })
 
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        observer.disconnect()
+      },
+      { once: true }
+    )
+
     // Ensure the initial theme state is synchronized with Giscus on page load
     updateGiscusTheme()
   })

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -25,11 +25,14 @@
 
 <script is:inline data-astro-rerun>
   // Initialize Giscus with the correct theme based on current state
-  const isDark = document.documentElement.classList.contains('dark')
-  const giscusScript = document.querySelector('script[src*="giscus.app/client.js"]')
-  if (giscusScript) {
-    giscusScript.setAttribute('data-theme', isDark ? 'dark' : 'light')
-  }
+  // This script runs after the Giscus script element is in the DOM
+  ;(() => {
+    const isDark = document.documentElement.classList.contains('dark')
+    const giscusScript = document.querySelector('script[src*="giscus.app/client.js"]')
+    if (giscusScript) {
+      giscusScript.setAttribute('data-theme', isDark ? 'dark' : 'light')
+    }
+  })()
 </script>
 
 <script>

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -1,5 +1,6 @@
 ---
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
+import Giscus from '@/components/Giscus.astro'
 import Link from '@/components/Link.astro'
 import PostNavigation from '@/components/PostNavigation.astro'
 import TableOfContents from '@/components/TableOfContents.astro'
@@ -136,6 +137,10 @@ const authors = await parseAuthors(post.data.authors ?? [])
     </article>
 
     <PostNavigation prevPost={prev} nextPost={next} />
+
+    <div class="col-start-2">
+      <Giscus />
+    </div>
   </section>
 
   <Button


### PR DESCRIPTION
Close: #5

## Summary by Sourcery

Integrate a GitHub Discussions–powered Giscus comments section into blog post pages.

New Features:
- Add a reusable Giscus comment component configured for the repository’s discussions.
- Render the comments section beneath blog posts with theme-aware styling that reacts to light/dark mode changes.